### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/402df420-2ae2-4c6f-9bf1-c7dfad13ef3b/f9199bfc-aeab-4aba-8da5-3ef59cceb72f/_apis/work/boardbadge/6d46ba70-23d3-4ca9-bf8a-4916a4232093)](https://dev.azure.com/aiw-devops/402df420-2ae2-4c6f-9bf1-c7dfad13ef3b/_boards/board/t/f9199bfc-aeab-4aba-8da5-3ef59cceb72f/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#549](https://dev.azure.com/aiw-devops/402df420-2ae2-4c6f-9bf1-c7dfad13ef3b/_workitems/edit/549). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.